### PR TITLE
Fixes the case where project .name or .iml file does not exist in .idea directory.

### DIFF
--- a/src/project/name.js
+++ b/src/project/name.js
@@ -28,6 +28,12 @@ const getProductName = (projectPath) => {
       const viaPath = `${projectPath}/.idea`;
       const imlFiles = getFiles(viaPath).filter(file => path.extname(file) === '.iml');
       return (imlFiles.length === 1) ? path.basename(imlFiles[0], '.iml') : false;
+    },
+    viaDirectoryName: () => {
+      if (!isIdeaDirExists) {
+        return false;
+      }
+      return path.basename(path.dirname(projectPath));
     }
   };
 


### PR DESCRIPTION
Fixes the case where project is a host for submodules only and no `.name` or `.iml` exists in the `.idea` directory.

How my project was created:
New project in a folder, subfolder to store *.iml module files (configurable on project screen).
Only contents of the folder are subfolders. Subfolders were added as new modules from existing sources.

I tried renaming my project to something other than the directory name, and idea created the `.name` file. IntelliJ deleted it when I renamed it back to the root directory name.
