### PR TITLE
Added pstorm bin for PhpStorm

### DIFF
--- a/src/products.json
+++ b/src/products.json
@@ -29,7 +29,7 @@
   },
   "PhpStorm": {
     "preferences": "PhpStorm",
-    "bin": ["pstorm", "phpstorm"]
+    "bin": ["phpstorm", "pstorm"]
   },
   "PyCharmPro": {
     "preferences": "PyCharm",

--- a/src/products.json
+++ b/src/products.json
@@ -29,7 +29,7 @@
   },
   "PhpStorm": {
     "preferences": "PhpStorm",
-    "bin": "phpstorm"
+    "bin": ["pstorm", "phpstorm"]
   },
   "PyCharmPro": {
     "preferences": "PyCharm",


### PR DESCRIPTION
`pstorm` is the default bin name for PhpStorm.

<img width="812" alt="image" src="https://user-images.githubusercontent.com/1086908/65023801-e6305f00-d933-11e9-9127-e1b5a5a64b6b.png">
