### PR TITLE
Fix search configuration

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -1,5 +1,6 @@
 const alfy = require("alfy");
 const fs = require("fs");
+const path = require("path");
 
 const searchOptions = () => {
   let fuseOptions = {
@@ -10,8 +11,8 @@ const searchOptions = () => {
     maxPatternLength: 32,
     minMatchCharLength: 2,
     keys: [
-      { name: "title", weight: 1 },
-      { name: "variables.jb_search_basename", weight: 0.5 }
+      { name: "title", weight: 0.9 },
+      { name: "variables.jb_search_basename", weight: 0.1 }
     ]
   };
 


### PR DESCRIPTION
This PR fixing 2 problems:
1. custom search (`jb_search_customisation_file`) doesn't work. Just because of missing `path`.
2. since `fuse.js@3.6.1` total weight couldn't exceed 1
```
Error: Total of weights cannot exceed 1
    at e.value (/usr/local/lib/node_modules/@bchatard/alfred-jetbrains/node_modules/fuse.js/dist/fuse.js:9:3409)
    at new e (/usr/local/lib/node_modules/@bchatard/alfred-jetbrains/node_modules/fuse.js/dist/fuse.js:9:2634)
    at /usr/local/lib/node_modules/@bchatard/alfred-jetbrains/src/index.js:31:20
    at Object.<anonymous> (/usr/local/lib/node_modules/@bchatard/alfred-jetbrains/src/index.js:60:3)
    at Object.<anonymous> (/usr/local/lib/node_modules/@bchatard/alfred-jetbrains/node_modules/esm/esm.js:1:251206)
    at /usr/local/lib/node_modules/@bchatard/alfred-jetbrains/node_modules/esm/esm.js:1:245054
    at Generator.next (<anonymous>)
    at bl (/usr/local/lib/node_modules/@bchatard/alfred-jetbrains/node_modules/esm/esm.js:1:245412)
    at kl (/usr/local/lib/node_modules/@bchatard/alfred-jetbrains/node_modules/esm/esm.js:1:247659)
    at Object.u (/usr/local/lib/node_modules/@bchatard/alfred-jetbrains/node_modules/esm/esm.js:1:287740)
```