### PR TITLE
Fix for undefined variable and for getting path on new product versions 2020.1+

### DIFF
--- a/src/product.js
+++ b/src/product.js
@@ -124,7 +124,7 @@ const getApplicationPath = (product) => {
   const binContent = fs.readFileSync(product.binPath, { encoding: "UTF-8" });
 
   // Toolbox case
-  const pattern = new RegExp('open -a "(.*)" "\\$@"');
+  const pattern = new RegExp('open -(n)?a "(.*)" (--args)? "\\$@"');
   const match = pattern.exec(binContent);
   if (match && match.length === 2) {
     let appPath = match[1];

--- a/src/product.js
+++ b/src/product.js
@@ -126,8 +126,8 @@ const getApplicationPath = (product) => {
   // Toolbox case
   const pattern = new RegExp('open -(n)?a "(.*)" (--args)? "\\$@"');
   const match = pattern.exec(binContent);
-  if (match && match.length === 2) {
-    let appPath = match[1];
+  if (match && [2, 4].includes(match.length)) {
+    let appPath = match.length === 2 ? match[1] : match[2];
     appPath = appPath.split("/");
     appPath = appPath.slice(0, -3); // remove last three entries ('Contents', 'MacOS', ${bin})
     appPath = appPath.join("/");
@@ -142,7 +142,7 @@ const getApplicationPath = (product) => {
     return oldMatch[1];
   }
 
-  throw new Error(`Can't find application path for ${binContent}`);
+  throw new Error(`Can't find application path for ${product.key}.`);
 };
 
 const get = () => {

--- a/src/product.js
+++ b/src/product.js
@@ -126,8 +126,10 @@ const getApplicationPath = (product) => {
   // Toolbox case
   const pattern = new RegExp('open -(n)?a "(.*)" (--args)? "\\$@"');
   const match = pattern.exec(binContent);
-  if (match && [2, 4].includes(match.length)) {
-    let appPath = match[match.length === 2 ? 1 : 2];
+  const matchLength = match.length;
+
+  if (match && [2, 4].includes(matchLength)) {
+    let appPath = match[matchLength === 2 ? 1 : 2];
     appPath = appPath.split("/");
     appPath = appPath.slice(0, -3); // remove last three entries ('Contents', 'MacOS', ${bin})
     appPath = appPath.join("/");

--- a/src/product.js
+++ b/src/product.js
@@ -142,7 +142,7 @@ const getApplicationPath = (product) => {
     return oldMatch[1];
   }
 
-  throw new Error(`Can't find application path for ${bin}`);
+  throw new Error(`Can't find application path for ${binContent}`);
 };
 
 const get = () => {

--- a/src/product.js
+++ b/src/product.js
@@ -127,7 +127,7 @@ const getApplicationPath = (product) => {
   const pattern = new RegExp('open -(n)?a "(.*)" (--args)? "\\$@"');
   const match = pattern.exec(binContent);
   if (match && [2, 4].includes(match.length)) {
-    let appPath = match.length === 2 ? match[1] : match[2];
+    let appPath = match[match.length === 2 ? 1 : 2];
     appPath = appPath.split("/");
     appPath = appPath.slice(0, -3); // remove last three entries ('Contents', 'MacOS', ${bin})
     appPath = appPath.join("/");


### PR DESCRIPTION
This is my proposed solution to issue https://github.com/bchatard/alfred-jetbrains/issues/126.

I hope that is okay, the main problem is that the file format changed and it seems it is something like this now: 

```bash
#!/bin/sh
# Generated by JetBrains Toolbox 1.17.6802 at 2020-04-23T16:32:07.006534

open -na "<TOOLBOX_PATH>/Toolbox/apps/PhpStorm/ch-0/201.6668.153/PhpStorm.app/Contents/MacOS/phpstorm" --args "$@"
```

With my fix the workflow ceases to complain/throw exceptions.