### PR TITLE
Fixes issue when there are project groups defined in 2020.3+ and workflof cannot find any projects

### DIFF
--- a/src/project/paths.js
+++ b/src/project/paths.js
@@ -47,7 +47,8 @@ const getProjectPaths = (productPath) => {
             ? application.component.option
             : [];
         // 2020.3+
-        if (typeof options === "object") {
+        if (!Array.isArray(options)) {
+          // if there are no project groups defined,
           // there is only one entry in 2020.3+, so we change it into array
           options = [options];
         }


### PR DESCRIPTION
Under 2020.3+ versions, when there are project groups defined, no projects can be found as options object is already an array.