### PR TITLE
Change Pattern to match the new toolbox shell script format

### DIFF
--- a/src/product.js
+++ b/src/product.js
@@ -125,7 +125,7 @@ const getApplicationPath = (product) => {
   const binContent = fs.readFileSync(product.binPath, { encoding: "UTF-8" });
 
   // Toolbox case
-  const pattern = new RegExp('open -(n)?a "(.*)"( --args)? "\\$@"');
+  const pattern = new RegExp('open\\s-(n)?a\\s"(.*)"(?:\\s\\$wait)?(\\s--args)\\s"\\$(?:{ideargs\\[)?@(?:]})?"');
   const match = pattern.exec(binContent);
   const matchLength = match ? match.length : 0;
 


### PR DESCRIPTION
I modified the regular expression to match the previous and new format for the shell scripts. Fixes #185 

Previous path:
 ![old-path](https://user-images.githubusercontent.com/2395800/102866476-9ba36980-4437-11eb-9645-aff5bb699423.png)

New path:
![new-path](https://user-images.githubusercontent.com/2395800/102866498-a4943b00-4437-11eb-9262-9c0e9fa1029f.png)
