### PR TITLE
⚡️ fix: add "ws" to webstorm bin

### DIFF
--- a/src/products.json
+++ b/src/products.json
@@ -41,6 +41,6 @@
   },
   "WebStorm": {
     "preferences": "WebStorm",
-    "bin": "webstorm"
+    "bin": ["webstorm", "ws"]
   }
 }


### PR DESCRIPTION
Many webstorm users use "ws" 😀