### PR TITLE
Get recent projects for Rider

### DIFF
--- a/src/project/paths.js
+++ b/src/project/paths.js
@@ -76,14 +76,23 @@ const getProjectPaths = (productPath) => {
         const application = content.application;
         const options =
           application.component &&
-          application.component["@_name"] === "RecentDirectoryProjectsManager"
+          application.component["@_name"] === "RiderRecentProjectsManager"
             ? application.component.option
             : [];
         const recentPathOptions = options.find((option) => {
           return option["@_name"] === "recentPaths";
         });
-
-        return recentPathOptions ? recentPathOptions.list.option : [];
+        if (recentPathOptions) {
+          return recentPathOptions.list.option;
+        }
+        // 2020.3+
+        const entries = options.find((option) => {
+          return option["@_name"] === "additionalInfo";
+        });
+        if (entries) {
+          return entries.map.entry;
+        }
+        return [];
       }
       return false;
     },


### PR DESCRIPTION
Partially fixes #5 based on @nanocortex's comments. 

This only works for projects that reference the directory (/Users/me/MyProject). It does not work for projects that reference the .sln file since it cannot find the project name (/Users/me/MyProject/MyProject.sln).