### PR TITLE
Update getting name for Rider solutions

### DIFF
--- a/src/project/name.js
+++ b/src/project/name.js
@@ -72,6 +72,12 @@ const getProductName = projectPath => {
 
       return false;
     },
+    viaSolution: () => {
+      let pathParts = projectPath.split('/');
+      let solutionName = pathParts[pathParts.length-1];
+      solutionName = solutionName.replace(".sln", "");
+      return solutionName;
+    },
     // fallback case, keep it in last position
     viaDirectoryName: () => {
       if (!isIdeaDirExists) {


### PR DESCRIPTION
#5 should be fully fixed now.
Fixes the issue with opening Rider solution files I mentioned in #227.

Rider will ask for permission the first time you open a solution, but it should only be that one time.
![Screenshot 2021-08-05 at 10 29 21](https://user-images.githubusercontent.com/5341280/128377494-19203c5b-df9d-4538-b5ff-b3bdbd879aa9.png)
 