### PR TITLE
Fixes error when one of the `preferencesPaths` folders doesn't exist 

### DIFF
--- a/src/findProduct.js
+++ b/src/findProduct.js
@@ -79,7 +79,7 @@ const getPreferencePath = (product) => {
       );
     } catch (e) {
       // error in getDirectories du to missing preferencesPath, die silently
-      break;
+      continue;
     }
 
     if (paths.length === 1) {


### PR DESCRIPTION
Hey

When a path from `preferencesPaths` doesnt exist `getDirectories` throws an exception which causes the catch block to trigger and the whole loop stops without a config dir.
With `continue` instead of `break` it works fine.