### PR TITLE
fix: can't get applicationPath with 2023+ new EAP

### DIFF
--- a/src/findProduct.js
+++ b/src/findProduct.js
@@ -137,6 +137,10 @@ const getApplicationPath = (product) => {
 
   product.binPath = binPath;
 
+  if (binPath.indexOf(".app")) {
+    return binPath.substring(0, binPath.lastIndexOf(".app") + 4);
+  }
+
   const binContent = fs.readFileSync(product.binPath, { encoding: "UTF-8" });
 
   // Toolbox case


### PR DESCRIPTION
### Summary
- In the 2023+ version, Jetbrains appears to have changed its CLI provision from an app file instead of bin file (eg. `/usr/bin/local/idea`). 
- According to `IntelliJ IDEA.app/Contents/MacOS/idea`, I changed codes get `ApplicationPath`.

![image](https://user-images.githubusercontent.com/40969251/232956038-eb844c53-23a6-4a73-ad64-6b6449e07a35.png)

- And we need to add `PATH` environment, alfred seems not to be import `/etc/paths`, so I has solved via add like below.

<img width="751" alt="image" src="https://user-images.githubusercontent.com/40969251/233261623-6a9e5e16-9bfb-48f9-aef7-fb483e472cda.png">

### Issues
- fix #310 

